### PR TITLE
feat: option to force panel button to display icons instead of text

### DIFF
--- a/i18n/en/cosmic_ext_tweaks.ftl
+++ b/i18n/en/cosmic_ext_tweaks.ftl
@@ -13,6 +13,7 @@ installed = Installed
 
 # Panel only
 show-panel = Show panel
+force-icon-buttons-in-panel = Force icon buttons in panel
 
 padding = Padding
 padding-description = Padding is the space between the contents and the borders of the dock or panel.

--- a/src/core/cosmic_panel_button_config.rs
+++ b/src/core/cosmic_panel_button_config.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+use cosmic::cosmic_config;
+use cosmic_config::{cosmic_config_derive::CosmicConfigEntry, CosmicConfigEntry};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, CosmicConfigEntry)]
+#[version = 1]
+#[serde(deny_unknown_fields)]
+pub struct CosmicPanelButtonConfig {
+    /// configs indexed by panel name
+    pub configs: HashMap<String, IndividualConfig>,
+}
+
+impl Default for CosmicPanelButtonConfig {
+    fn default() -> Self {
+        Self {
+            configs: HashMap::from([
+                (
+                    "Panel".to_string(),
+                    IndividualConfig {
+                        force_presentation: None,
+                    },
+                ),
+                (
+                    "Dock".to_string(),
+                    IndividualConfig {
+                        force_presentation: Some(Override::Icon),
+                    },
+                ),
+            ]),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default, Clone)]
+pub struct IndividualConfig {
+    pub force_presentation: Option<Override>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub enum Override {
+    Icon,
+    Text,
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod cosmic_panel_button_config;
 pub mod icons;
 pub mod localization;
 pub mod nav;


### PR DESCRIPTION
This commit adds the ability to tell COSMIC panel buttons (for example, the Launcher button, the App Library button, and the Workspaces button) to always present themselves as an icon on a Panel instead of being text on horizontal panels, and icons on vertical panels.

> **NOTE:** It's a bit messy atm as I just copied the cosmic panel button config into the source here, but I don't think the config is exported in such a way that we could get it from cosmic-applets. Correct me if I'm wrong!


https://github.com/user-attachments/assets/f02b79b1-9748-41d6-9599-58ef3a17ccce

