### PR TITLE
Move available color schemes to a dialog

### DIFF
--- a/i18n/en/cosmic_ext_tweaks.ftl
+++ b/i18n/en/cosmic_ext_tweaks.ftl
@@ -10,6 +10,7 @@ color-schemes-error = Error loading color schemes
 import-color-scheme = Import color scheme
 delete-color-scheme = Delete color scheme
 delete-layout = Delete layout
+available-color-schemes-body = Find and install color schemes.
 install-color-scheme = Install color scheme
 find-color-schemes = Find color schemes
 open-containing-folder = Open containing folder
@@ -34,6 +35,7 @@ spacing-description = Spacing is the space between the icons in the dock or pane
 
 save = Save
 cancel = Cancel
+close = Close
 save-current-color-scheme = Save current color scheme
 save-current-layout = Save current layout
 color-scheme-name = Color scheme name

--- a/src/app.rs
+++ b/src/app.rs
@@ -648,7 +648,6 @@ impl TweakTool {
                 let widgets = widget::flex_row(themes)
                     .row_spacing(spacing.space_xs)
                     .column_spacing(spacing.space_xs)
-                    .min_item_width(Some(400.0))
                     .apply(widget::container)
                     .padding([0, spacing.space_xxs]);
                 Some(widgets.into())

--- a/src/app/style.rs
+++ b/src/app/style.rs
@@ -1,11 +1,13 @@
 use cosmic::{
-    cosmic_theme::Theme,
+    cosmic_theme::{Component, Theme},
     iced::{Background, Border, Color},
     iced_core::Shadow,
-    widget::{self, button, container},
+    theme::{Button, TRANSPARENT_COMPONENT},
+    widget::{self, container},
 };
 
-pub fn background<'a>(theme: Theme) -> cosmic::theme::Container<'a> {
+pub fn background<'a>(theme: &Theme) -> cosmic::theme::Container<'a> {
+    let theme = theme.clone();
     let corner_radii = cosmic::theme::active().cosmic().corner_radii;
     cosmic::theme::Container::custom(move |_| container::Style {
         icon_color: Some(Color::from(theme.background.on)),
@@ -53,38 +55,335 @@ pub fn panel_style(theme: &cosmic::Theme) -> widget::container::Style {
     }
 }
 
-#[allow(dead_code)]
-pub fn standard_button(theme: Theme) -> cosmic::theme::Button {
-    let active_theme = theme.clone();
-    let disabled_theme = theme.clone();
-    let hovered_theme = theme.clone();
-    let pressed_theme = theme.clone();
-    let _corner_radii = cosmic::theme::active().cosmic().corner_radii;
+pub fn standard_button(theme: Theme) -> Button {
+    let theme_active = theme.clone();
+    let theme_disabled = theme.clone();
+    let theme_hovered = theme.clone();
+    let theme_pressed = theme;
 
-    cosmic::theme::Button::Custom {
-        active: Box::new(move |_active, _cosmic| button::Style {
-            background: Some(cosmic::iced_core::Background::Color(
-                active_theme.on_accent_color().into(),
-            )),
-            ..Default::default()
+    Button::Custom {
+        active: Box::new(move |_, _| {
+            appearance(
+                &theme_active,
+                false,
+                false,
+                false,
+                Button::Standard,
+                |component| {
+                    let text_color = Some(component.on.into());
+                    (component.hover.into(), text_color, text_color)
+                },
+            )
         }),
-        disabled: Box::new(move |_cosmic| button::Style {
-            background: Some(cosmic::iced_core::Background::Color(
-                disabled_theme.on_accent_color().into(),
-            )),
-            ..Default::default()
+        disabled: Box::new(move |_| {
+            appearance(
+                &theme_disabled,
+                false,
+                false,
+                true,
+                Button::Standard,
+                |component| {
+                    let mut background = Color::from(component.base);
+                    background.a *= 0.5;
+                    (
+                        background,
+                        Some(component.on_disabled.into()),
+                        Some(component.on_disabled.into()),
+                    )
+                },
+            )
         }),
-        hovered: Box::new(move |_hovered, _cosmic| button::Style {
-            background: Some(cosmic::iced_core::Background::Color(
-                hovered_theme.on_accent_color().into(),
-            )),
-            ..Default::default()
+        hovered: Box::new(move |_, _| {
+            appearance(
+                &theme_hovered,
+                false,
+                false,
+                false,
+                Button::Standard,
+                |component| {
+                    let text_color = Some(component.on.into());
+
+                    (component.hover.into(), text_color, text_color)
+                },
+            )
         }),
-        pressed: Box::new(move |_pressed, _cosmic| button::Style {
-            background: Some(cosmic::iced_core::Background::Color(
-                pressed_theme.on_accent_color().into(),
-            )),
-            ..Default::default()
+        pressed: Box::new(move |_, _| {
+            appearance(
+                &theme_pressed,
+                false,
+                false,
+                false,
+                Button::Standard,
+                |component| {
+                    let text_color = Some(component.on.into());
+
+                    (component.pressed.into(), text_color, text_color)
+                },
+            )
         }),
     }
+}
+
+pub fn destructive_button(theme: Theme) -> Button {
+    let theme_active = theme.clone();
+    let theme_disabled = theme.clone();
+    let theme_hovered = theme.clone();
+    let theme_pressed = theme;
+
+    Button::Custom {
+        active: Box::new(move |_, _| {
+            appearance(
+                &theme_active,
+                false,
+                false,
+                false,
+                Button::Destructive,
+                |component| {
+                    let text_color = Some(component.on.into());
+                    (component.hover.into(), text_color, text_color)
+                },
+            )
+        }),
+        disabled: Box::new(move |_| {
+            appearance(
+                &theme_disabled,
+                false,
+                false,
+                true,
+                Button::Destructive,
+                |component| {
+                    let mut background = Color::from(component.base);
+                    background.a *= 0.5;
+                    (
+                        background,
+                        Some(component.on_disabled.into()),
+                        Some(component.on_disabled.into()),
+                    )
+                },
+            )
+        }),
+        hovered: Box::new(move |_, _| {
+            appearance(
+                &theme_hovered,
+                false,
+                false,
+                false,
+                Button::Destructive,
+                |component| {
+                    let text_color = Some(component.on.into());
+
+                    (component.hover.into(), text_color, text_color)
+                },
+            )
+        }),
+        pressed: Box::new(move |_, _| {
+            appearance(
+                &theme_pressed,
+                false,
+                false,
+                false,
+                Button::Destructive,
+                |component| {
+                    let text_color = Some(component.on.into());
+
+                    (component.pressed.into(), text_color, text_color)
+                },
+            )
+        }),
+    }
+}
+
+pub fn link_button(theme: Theme) -> Button {
+    let theme_active = theme.clone();
+    let theme_disabled = theme.clone();
+    let theme_hovered = theme.clone();
+    let theme_pressed = theme;
+
+    Button::Custom {
+        active: Box::new(move |_, _| {
+            appearance(
+                &theme_active,
+                false,
+                false,
+                false,
+                Button::Link,
+                |component| {
+                    let text_color = Some(component.on.into());
+                    (component.hover.into(), text_color, text_color)
+                },
+            )
+        }),
+        disabled: Box::new(move |_| {
+            appearance(
+                &theme_disabled,
+                false,
+                false,
+                true,
+                Button::Link,
+                |component| {
+                    let mut background = Color::from(component.base);
+                    background.a *= 0.5;
+                    (
+                        background,
+                        Some(component.on_disabled.into()),
+                        Some(component.on_disabled.into()),
+                    )
+                },
+            )
+        }),
+        hovered: Box::new(move |_, _| {
+            appearance(
+                &theme_hovered,
+                false,
+                false,
+                false,
+                Button::Link,
+                |component| {
+                    let text_color = Some(component.on.into());
+
+                    (component.hover.into(), text_color, text_color)
+                },
+            )
+        }),
+        pressed: Box::new(move |_, _| {
+            appearance(
+                &theme_pressed,
+                false,
+                false,
+                false,
+                Button::Link,
+                |component| {
+                    let text_color = Some(component.on.into());
+
+                    (component.pressed.into(), text_color, text_color)
+                },
+            )
+        }),
+    }
+}
+
+pub fn appearance(
+    theme: &Theme,
+    focused: bool,
+    selected: bool,
+    disabled: bool,
+    style: Button,
+    color: impl Fn(&Component) -> (Color, Option<Color>, Option<Color>),
+) -> widget::button::Style {
+    let cosmic = theme;
+    let mut corner_radii = &cosmic.corner_radii.radius_xl;
+    let mut appearance = widget::button::Style::new();
+
+    match style {
+        Button::Standard
+        | Button::Text
+        | Button::Suggested
+        | Button::Destructive
+        | Button::Transparent => {
+            let style_component = match style {
+                Button::Standard => &cosmic.button,
+                Button::Text => &cosmic.text_button,
+                Button::Suggested => &cosmic.accent_button,
+                Button::Destructive => &cosmic.destructive_button,
+                Button::Transparent => &TRANSPARENT_COMPONENT,
+                _ => return appearance,
+            };
+
+            let (background, text, icon) = color(style_component);
+            appearance.background = Some(Background::Color(background));
+            if !matches!(style, Button::Standard) {
+                appearance.text_color = text;
+                appearance.icon_color = icon;
+            }
+        }
+
+        Button::Icon | Button::IconVertical | Button::HeaderBar => {
+            if matches!(style, Button::IconVertical) {
+                corner_radii = &cosmic.corner_radii.radius_m;
+                if selected {
+                    appearance.overlay = Some(Background::Color(Color::from(
+                        cosmic.icon_button.selected_state_color(),
+                    )));
+                }
+            }
+
+            let (background, text, icon) = color(&cosmic.icon_button);
+            appearance.background = Some(Background::Color(background));
+            // Only override icon button colors when it is disabled
+            appearance.icon_color = if disabled { icon } else { None };
+            appearance.text_color = if disabled { text } else { None };
+        }
+
+        Button::Image => {
+            appearance.background = None;
+            appearance.text_color = Some(cosmic.accent.base.into());
+            appearance.icon_color = Some(cosmic.accent.base.into());
+
+            corner_radii = &cosmic.corner_radii.radius_s;
+            appearance.border_radius = (*corner_radii).into();
+
+            if focused || selected {
+                appearance.border_width = 2.0;
+                appearance.border_color = cosmic.accent.base.into();
+            }
+
+            return appearance;
+        }
+
+        Button::Link => {
+            appearance.background = None;
+            appearance.icon_color = Some(cosmic.accent.base.into());
+            appearance.text_color = Some(cosmic.accent.base.into());
+            corner_radii = &cosmic.corner_radii.radius_0;
+        }
+
+        Button::Custom { .. } => (),
+        Button::AppletMenu => {
+            let (background, _, _) = color(&cosmic.text_button);
+            appearance.background = Some(Background::Color(background));
+
+            appearance.icon_color = Some(cosmic.background.on.into());
+            appearance.text_color = Some(cosmic.background.on.into());
+            corner_radii = &cosmic.corner_radii.radius_0;
+        }
+        Button::AppletIcon => {
+            let (background, _, _) = color(&cosmic.text_button);
+            appearance.background = Some(Background::Color(background));
+
+            appearance.icon_color = Some(cosmic.background.on.into());
+            appearance.text_color = Some(cosmic.background.on.into());
+        }
+        Button::MenuFolder => {
+            // Menu folders cannot be disabled, ignore customized icon and text color
+            let component = &cosmic.background.component;
+            let (background, _, _) = color(component);
+            appearance.background = Some(Background::Color(background));
+            appearance.icon_color = Some(component.on.into());
+            appearance.text_color = Some(component.on.into());
+            corner_radii = &cosmic.corner_radii.radius_s;
+        }
+        Button::MenuItem => {
+            let (background, text, icon) = color(&cosmic.background.component);
+            appearance.background = Some(Background::Color(background));
+            appearance.icon_color = icon;
+            appearance.text_color = text;
+            corner_radii = &cosmic.corner_radii.radius_s;
+        }
+        Button::MenuRoot => {
+            appearance.background = None;
+            appearance.icon_color = None;
+            appearance.text_color = None;
+        }
+    }
+
+    appearance.border_radius = (*corner_radii).into();
+
+    if focused {
+        appearance.outline_width = 1.0;
+        appearance.outline_color = cosmic.accent.base.into();
+        appearance.border_width = 2.0;
+        appearance.border_color = Color::TRANSPARENT;
+    }
+
+    appearance
 }

--- a/src/pages/color_schemes.rs
+++ b/src/pages/color_schemes.rs
@@ -105,68 +105,6 @@ pub enum ColorSchemeProvider {
 }
 
 impl ColorSchemes {
-    pub fn view<'a>(&self) -> Element<'a, Message> {
-        let spacing = cosmic::theme::active().cosmic().spacing;
-
-        widget::column::with_children(vec![
-            widget::row::with_children(vec![
-                widget::text::title3(fl!("color-schemes")).into(),
-                widget::horizontal_space().into(),
-                widget::tooltip::tooltip(
-                    icons::get_handle("arrow-into-box-symbolic", 16)
-                        .apply(widget::button::icon)
-                        .padding(spacing.space_xxs)
-                        .on_press(Message::SaveCurrentColorScheme(None))
-                        .class(cosmic::style::Button::Standard),
-                    widget::text(fl!("save-current-color-scheme")),
-                    tooltip::Position::Bottom,
-                )
-                .into(),
-                widget::tooltip::tooltip(
-                    icons::get_handle("document-save-symbolic", 16)
-                        .apply(widget::button::icon)
-                        .padding(spacing.space_xxs)
-                        .on_press(Message::StartImport)
-                        .class(cosmic::style::Button::Standard),
-                    widget::text(fl!("import-color-scheme")),
-                    tooltip::Position::Bottom,
-                )
-                .into(),
-                widget::tooltip::tooltip(
-                    icons::get_handle("search-global-symbolic", 16)
-                        .apply(widget::button::icon)
-                        .padding(spacing.space_xxs)
-                        .on_press(Message::OpenAvailableThemes)
-                        .class(cosmic::style::Button::Standard),
-                    widget::text(fl!("find-color-schemes")),
-                    tooltip::Position::Bottom,
-                )
-                .into(),
-            ])
-            .spacing(spacing.space_xxs)
-            .into(),
-            widget::settings::section()
-                .title(fl!("installed"))
-                .add({
-                    let themes: Vec<Element<Message>> = self
-                        .installed
-                        .iter()
-                        .map(|color_scheme| preview::installed(color_scheme, &self.selected))
-                        .collect();
-
-                    widget::flex_row(themes)
-                        .row_spacing(spacing.space_xs)
-                        .column_spacing(spacing.space_xs)
-                        .apply(widget::container)
-                        .padding([0, spacing.space_xxs])
-                })
-                .into(),
-        ])
-        .spacing(spacing.space_xxs)
-        .apply(widget::scrollable)
-        .into()
-    }
-
     pub fn update(&mut self, message: Message) -> Task<Message> {
         let mut commands = vec![];
         match message {
@@ -383,6 +321,68 @@ impl ColorSchemes {
             }
         }
         Task::batch(commands)
+    }
+
+    pub fn view<'a>(&self) -> Element<'a, Message> {
+        let spacing = cosmic::theme::active().cosmic().spacing;
+
+        widget::column::with_children(vec![
+            widget::row::with_children(vec![
+                widget::text::title3(fl!("color-schemes")).into(),
+                widget::horizontal_space().into(),
+                widget::tooltip::tooltip(
+                    icons::get_handle("arrow-into-box-symbolic", 16)
+                        .apply(widget::button::icon)
+                        .padding(spacing.space_xxs)
+                        .on_press(Message::SaveCurrentColorScheme(None))
+                        .class(cosmic::style::Button::Standard),
+                    widget::text(fl!("save-current-color-scheme")),
+                    tooltip::Position::Bottom,
+                )
+                .into(),
+                widget::tooltip::tooltip(
+                    icons::get_handle("document-save-symbolic", 16)
+                        .apply(widget::button::icon)
+                        .padding(spacing.space_xxs)
+                        .on_press(Message::StartImport)
+                        .class(cosmic::style::Button::Standard),
+                    widget::text(fl!("import-color-scheme")),
+                    tooltip::Position::Bottom,
+                )
+                .into(),
+                widget::tooltip::tooltip(
+                    icons::get_handle("search-global-symbolic", 16)
+                        .apply(widget::button::icon)
+                        .padding(spacing.space_xxs)
+                        .on_press(Message::OpenAvailableThemes)
+                        .class(cosmic::style::Button::Standard),
+                    widget::text(fl!("find-color-schemes")),
+                    tooltip::Position::Bottom,
+                )
+                .into(),
+            ])
+            .spacing(spacing.space_xxs)
+            .into(),
+            widget::settings::section()
+                .title(fl!("installed"))
+                .add({
+                    let themes: Vec<Element<Message>> = self
+                        .installed
+                        .iter()
+                        .map(|color_scheme| preview::installed(color_scheme, &self.selected))
+                        .collect();
+
+                    widget::flex_row(themes)
+                        .row_spacing(spacing.space_xs)
+                        .column_spacing(spacing.space_xs)
+                        .apply(widget::container)
+                        .padding([0, spacing.space_xxs])
+                })
+                .into(),
+        ])
+        .spacing(spacing.space_xxs)
+        .apply(widget::scrollable)
+        .into()
     }
 
     pub fn fetch_color_schemes() -> anyhow::Result<Vec<ColorScheme>> {

--- a/src/pages/color_schemes.rs
+++ b/src/pages/color_schemes.rs
@@ -376,7 +376,6 @@ impl ColorSchemes {
                         .row_spacing(spacing.space_xs)
                         .column_spacing(spacing.space_xs)
                         .apply(widget::container)
-                        .padding([0, spacing.space_xxs])
                 })
                 .into(),
         ])

--- a/src/pages/color_schemes/preview.rs
+++ b/src/pages/color_schemes/preview.rs
@@ -80,58 +80,52 @@ pub fn available<'a>(color_scheme: &ColorScheme) -> Element<'a, crate::app::Mess
         theme_caption.push(widget::text::caption(author.clone()).into());
     }
 
-    widget::button::custom(
-        widget::column::with_children(vec![
-            widget::column::with_children(theme_caption)
+    widget::column::with_children(vec![
+        widget::column::with_children(theme_caption)
+            .width(Length::Fill)
+            .align_x(Alignment::Center)
+            .padding([spacing.space_xxs, spacing.space_none])
+            .into(),
+        widget::row::with_children(vec![
+            widget::container(widget::text("Navigation"))
+                .padding(spacing.space_xxs)
                 .width(Length::Fill)
-                .align_x(Alignment::Center)
-                .padding([spacing.space_xxs, spacing.space_none])
+                .height(Length::Fill)
+                .class(crate::app::style::card(theme.clone()))
                 .into(),
-            widget::row::with_children(vec![
-                widget::container(widget::text("Navigation"))
+            widget::horizontal_space().into(),
+            widget::tooltip::tooltip(
+                icons::get_handle("symbolic-link-symbolic", 14)
+                    .apply(widget::button::icon)
+                    .class(cosmic::style::Button::Link)
                     .padding(spacing.space_xxs)
-                    .width(Length::Fixed(100.0))
-                    .height(Length::Fill)
-                    .class(crate::app::style::card(theme.clone()))
-                    .into(),
-                widget::horizontal_space().into(),
-                widget::tooltip::tooltip(
-                    icons::get_handle("symbolic-link-symbolic", 14)
-                        .apply(widget::button::icon)
-                        .class(cosmic::style::Button::Link)
-                        .padding(spacing.space_xxs)
-                        .on_press(crate::app::Message::ColorSchemes(Box::new(
-                            super::Message::OpenLink(color_scheme.link.clone()),
-                        ))),
-                    widget::text(fl!("open-link")),
-                    cosmic::widget::tooltip::Position::Bottom,
-                )
-                .into(),
-                widget::tooltip::tooltip(
-                    icons::get_handle("folder-download-symbolic", 14)
-                        .apply(widget::button::icon)
-                        .class(cosmic::style::Button::Suggested)
-                        .padding(spacing.space_xxs)
-                        .on_press(crate::app::Message::ColorSchemes(Box::new(
-                            super::Message::InstallColorScheme(color_scheme.clone()),
-                        ))),
-                    widget::text(fl!("install-color-scheme")),
-                    cosmic::widget::tooltip::Position::Bottom,
-                )
-                .into(),
-            ])
-            .align_y(Alignment::End)
-            .spacing(spacing.space_xxs)
-            .padding([0, spacing.space_xxs, spacing.space_xxs, spacing.space_xxs])
+                    .on_press(crate::app::Message::ColorSchemes(Box::new(
+                        super::Message::OpenLink(color_scheme.link.clone()),
+                    ))),
+                widget::text(fl!("open-link")),
+                cosmic::widget::tooltip::Position::Bottom,
+            )
+            .into(),
+            widget::tooltip::tooltip(
+                icons::get_handle("folder-download-symbolic", 14)
+                    .apply(widget::button::icon)
+                    .class(cosmic::style::Button::Suggested)
+                    .padding(spacing.space_xxs)
+                    .on_press(crate::app::Message::ColorSchemes(Box::new(
+                        super::Message::InstallColorScheme(color_scheme.clone()),
+                    ))),
+                widget::text(fl!("install-color-scheme")),
+                cosmic::widget::tooltip::Position::Bottom,
+            )
             .into(),
         ])
-        .height(Length::Fixed(160.0))
-        .apply(widget::container)
-        .class(crate::app::style::background(theme.clone())),
-    )
-    .class(cosmic::style::Button::Image)
-    .on_press(crate::app::Message::ColorSchemes(Box::new(
-        super::Message::SetColorScheme(color_scheme.clone()),
-    )))
+        .align_y(Alignment::End)
+        .spacing(spacing.space_xxs)
+        .padding([0, spacing.space_xxs, spacing.space_xxs, spacing.space_xxs])
+        .into(),
+    ])
+    .height(Length::Fixed(160.0))
+    .apply(widget::container)
+    .class(crate::app::style::background(theme.clone()))
     .into()
 }

--- a/src/pages/color_schemes/preview.rs
+++ b/src/pages/color_schemes/preview.rs
@@ -1,4 +1,7 @@
-use crate::fl;
+use crate::{
+    app::style::{destructive_button, link_button, standard_button},
+    fl,
+};
 use cosmic::{
     iced::{Alignment, Length},
     widget::{self, tooltip},
@@ -28,7 +31,7 @@ pub fn installed<'a>(
             widget::row::with_children(vec![
                 widget::container(widget::text("Navigation"))
                     .padding(spacing.space_xxs)
-                    .width(Length::Fixed(100.0))
+                    .width(90.0)
                     .height(Length::Fill)
                     .class(crate::app::style::card(theme.clone()))
                     .into(),
@@ -36,7 +39,7 @@ pub fn installed<'a>(
                 widget::tooltip::tooltip(
                     icons::get_handle("symbolic-link-symbolic", 14)
                         .apply(widget::button::icon)
-                        .class(cosmic::style::Button::Link)
+                        .class(link_button(theme.clone()))
                         .padding(spacing.space_xxs)
                         .on_press(super::Message::OpenContainingFolder(color_scheme.clone())),
                     widget::text(fl!("open-containing-folder")),
@@ -46,7 +49,7 @@ pub fn installed<'a>(
                 widget::tooltip::tooltip(
                     icons::get_handle("user-trash-symbolic", 14)
                         .apply(widget::button::icon)
-                        .class(cosmic::style::Button::Destructive)
+                        .class(destructive_button(theme.clone()))
                         .padding(spacing.space_xxs)
                         .on_press(super::Message::DeleteColorScheme(color_scheme.clone())),
                     widget::text(fl!("delete-color-scheme")),
@@ -62,7 +65,7 @@ pub fn installed<'a>(
         .width(Length::Fixed(200.0))
         .height(Length::Fixed(160.0))
         .apply(widget::container)
-        .class(crate::app::style::background(theme.clone())),
+        .class(crate::app::style::background(&theme)),
     )
     .selected(selected.name == color_scheme.name)
     .class(cosmic::style::Button::Image)
@@ -89,7 +92,7 @@ pub fn available<'a>(color_scheme: &ColorScheme) -> Element<'a, crate::app::Mess
         widget::row::with_children(vec![
             widget::container(widget::text("Navigation"))
                 .padding(spacing.space_xxs)
-                .width(Length::Fill)
+                .width(90.0)
                 .height(Length::Fill)
                 .class(crate::app::style::card(theme.clone()))
                 .into(),
@@ -97,7 +100,7 @@ pub fn available<'a>(color_scheme: &ColorScheme) -> Element<'a, crate::app::Mess
             widget::tooltip::tooltip(
                 icons::get_handle("symbolic-link-symbolic", 14)
                     .apply(widget::button::icon)
-                    .class(cosmic::style::Button::Link)
+                    .class(link_button(theme.clone()))
                     .padding(spacing.space_xxs)
                     .on_press(crate::app::Message::ColorSchemes(Box::new(
                         super::Message::OpenLink(color_scheme.link.clone()),
@@ -109,7 +112,7 @@ pub fn available<'a>(color_scheme: &ColorScheme) -> Element<'a, crate::app::Mess
             widget::tooltip::tooltip(
                 icons::get_handle("folder-download-symbolic", 14)
                     .apply(widget::button::icon)
-                    .class(cosmic::style::Button::Suggested)
+                    .class(standard_button(theme.clone()))
                     .padding(spacing.space_xxs)
                     .on_press(crate::app::Message::ColorSchemes(Box::new(
                         super::Message::InstallColorScheme(color_scheme.clone()),
@@ -124,8 +127,9 @@ pub fn available<'a>(color_scheme: &ColorScheme) -> Element<'a, crate::app::Mess
         .padding([0, spacing.space_xxs, spacing.space_xxs, spacing.space_xxs])
         .into(),
     ])
-    .height(Length::Fixed(160.0))
+    .width(240.0)
+    .height(160.0)
     .apply(widget::container)
-    .class(crate::app::style::background(theme.clone()))
+    .class(crate::app::style::background(&theme))
     .into()
 }


### PR DESCRIPTION
This PR moves the available color schemes list to a dialog window, this also fixes an issue where theme rendering would use the system theme instead of the previewed theme.

![image](https://github.com/user-attachments/assets/c46793ee-6b2c-43d3-838e-b8ec1224d6d8)

Closes #31 