### PR TITLE
fix: building for flatpak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ target/
 /.flatpak-builder
 /repo
 /flatpak-out
+
+vendor/
+
+.cargo/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,37 +776,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "calloop"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ead1e1514bce44c0f40e027899fbc595907fc112635bed21b3b5d975c0a5e7"
-dependencies = [
- "bitflags 2.6.0",
- "polling 3.7.0",
- "rustix 0.38.34",
- "slab",
- "tracing",
-]
-
-[[package]]
 name = "calloop-wayland-source"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "calloop 0.13.0",
- "rustix 0.38.34",
- "wayland-backend",
- "wayland-client",
-]
-
-[[package]]
-name = "calloop-wayland-source"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a7a1dbbe026a55ef47a500b123af5a9a0914520f061d467914cf21be95daf"
-dependencies = [
- "calloop 0.14.1",
+ "calloop",
  "rustix 0.38.34",
  "wayland-backend",
  "wayland-client",
@@ -1131,8 +1106,8 @@ dependencies = [
 
 [[package]]
 name = "cosmic-ext-config-templates"
-version = "2.0.1"
-source = "git+https://github.com/ryanabx/cosmic-ext-config-templates#8eedaf201a415e8bddf423f1b92580c6c74dc23e"
+version = "2.0.2"
+source = "git+https://github.com/ryanabx/cosmic-ext-config-templates#250a5c7a19a1626fb047da07808531cfd55819a5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1180,7 +1155,7 @@ dependencies = [
  "cosmic-config",
  "ron",
  "serde",
- "smithay-client-toolkit 0.19.2 (git+https://github.com/Smithay/client-toolkit)",
+ "smithay-client-toolkit",
  "tracing",
  "wayland-protocols-wlr",
  "xdg-shell-wrapper-config",
@@ -1493,7 +1468,7 @@ dependencies = [
  "bitflags 2.6.0",
  "mime 0.1.0",
  "raw-window-handle",
- "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-client-toolkit",
  "smithay-clipboard",
 ]
 
@@ -2744,7 +2719,7 @@ dependencies = [
  "resvg",
  "rustc-hash 2.0.0",
  "rustix 0.38.34",
- "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-client-toolkit",
  "thiserror",
  "tiny-xlib",
  "wayland-backend",
@@ -4869,7 +4844,7 @@ dependencies = [
  "ab_glyph",
  "log",
  "memmap2 0.9.4",
- "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-client-toolkit",
  "tiny-skia",
 ]
 
@@ -5076,35 +5051,8 @@ checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
- "calloop 0.13.0",
- "calloop-wayland-source 0.3.0",
- "cursor-icon",
- "libc",
- "log",
- "memmap2 0.9.4",
- "pkg-config",
- "rustix 0.38.34",
- "thiserror",
- "wayland-backend",
- "wayland-client",
- "wayland-csd-frame",
- "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-wlr",
- "wayland-scanner",
- "xkbcommon",
- "xkeysym",
-]
-
-[[package]]
-name = "smithay-client-toolkit"
-version = "0.19.2"
-source = "git+https://github.com/Smithay/client-toolkit#618a876400cb6c6b07a8ac5d3557f404602ec077"
-dependencies = [
- "bitflags 2.6.0",
- "bytemuck",
- "calloop 0.14.1",
- "calloop-wayland-source 0.4.0",
+ "calloop",
+ "calloop-wayland-source",
  "cursor-icon",
  "libc",
  "log",
@@ -5130,7 +5078,7 @@ source = "git+https://github.com/pop-os/smithay-clipboard?tag=pop-dnd-5#5a3007de
 dependencies = [
  "libc",
  "raw-window-handle",
- "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-client-toolkit",
  "wayland-backend",
 ]
 
@@ -5673,7 +5621,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6680,7 +6627,7 @@ dependencies = [
  "bitflags 2.6.0",
  "block2",
  "bytemuck",
- "calloop 0.13.0",
+ "calloop",
  "cfg_aliases 0.2.1",
  "concurrent-queue",
  "core-foundation",
@@ -6702,7 +6649,7 @@ dependencies = [
  "redox_syscall 0.4.1",
  "rustix 0.38.34",
  "sctk-adwaita",
- "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-client-toolkit",
  "smol_str",
  "tracing",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,6 @@ features = ["macros", "fs", "rt"]
 
 [build-dependencies]
 vergen = { version = "8", features = ["git", "gitcl"] }
+
+[patch."https://github.com/smithay/client-toolkit.git"]
+sctk = { package = "smithay-client-toolkit", version = "=0.19.2" }


### PR DESCRIPTION
this commit fixes building for flatpak by adding a patch to sctk

I tried this with cargo build --offline and it worked