### PR TITLE
Implement Theme Packs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,8 +1146,10 @@ dependencies = [
  "ron 0.8.1",
  "rust-embed",
  "serde",
+ "serde_json",
  "thiserror 2.0.12",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ ron = "0.8.1"
 rust-embed = "8.3.0"
 chrono = { version = "0.4.38", features = ["serde"] }
 thiserror = "2.0.12"
+serde_json = "1.0.140"
+url = "2.5.0"
 
 [dependencies.ashpd]
 version = "0.8.1"
@@ -24,7 +26,7 @@ features = ["async-std"]
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic.git"
 default-features = false
-features = ["tokio", "winit", "wgpu", "about"]
+features = ["tokio", "winit", "wgpu", "about", "xdg-portal"]
 
 [dependencies.cosmic-ext-config-templates]
 git = "https://github.com/ryanabx/cosmic-ext-config-templates"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@
 ![color-schemes-light.png](res/screenshots/color-schemes-light.png#gh-light-mode-only)
 ![color-schemes-dark.png](res/screenshots/color-schemes-dark.png#gh-dark-mode-only)
 
+## Features
+
+### Theme Packs
+Theme Packs allow you to save, load, and share complete desktop configurations including:
+- Color schemes
+- Panel and dock layouts
+- Desktop appearance settings
+
+Theme packs are stored as `.ctp` files in `~/.config/cosmic/theme_packs/`.
+
+To create a theme pack:
+1. Navigate to the Theme Packs section
+2. Enter a name, author, and description
+3. Click "Export Theme"
+
+To import a theme pack:
+1. Navigate to the Theme Packs section
+2. Click "Import Color Scheme"
+3. Select a `.ctp` file using the file dialog
+4. Select and apply the imported theme
+
 ## Getting Started
 Clone this repository to your local machine and open it in your code editor.
 

--- a/i18n/en/cosmic_ext_tweaks.ftl
+++ b/i18n/en/cosmic_ext_tweaks.ftl
@@ -9,6 +9,7 @@ color-schemes = Color schemes
 layouts = Layouts
 shortcuts = Shortcuts
 snapshots = Snapshots
+theme-packs = Theme Packs
 
 color-schemes-error = Error loading color schemes
 import-color-scheme = Import color scheme
@@ -37,6 +38,8 @@ save = Save
 cancel = Cancel
 close = Close
 create = Create
+delete = Delete
+apply = Apply
 
 navigation = Navigation
 
@@ -54,6 +57,15 @@ created = Created
 actions = Actions
 system = System
 user = User
+
+# Theme Packs
+available-themes = Available Themes
+no-themes-available = No themes available
+create-new-theme = Create New Theme
+export-theme = Export Theme
+author = Author
+description = Description
+save-theme-confirmation = Do you want to save this theme pack?
 
 ## Snapshots
 application-opened = Application opened
@@ -78,7 +90,7 @@ light = Light
 view = View
 
 
-## Shortcuts
+## Shortcuts
 
 warning = Warning: this will remove your existing custom shortcuts
 windows-desc = Super+Arrows to move windows. Ctrl+Alt+Arrows to navigate workspaces.

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,6 +22,7 @@ pub struct App {
     layouts: pages::Layouts,
     snapshots: pages::Snapshots,
     shorcuts: pages::Shortcuts,
+    theme_packs: pages::ThemePacks,
 }
 
 impl App {

--- a/src/app/cosmic.rs
+++ b/src/app/cosmic.rs
@@ -43,6 +43,7 @@ use crate::{
         shortcuts::Shortcuts,
         snapshots::{config::SnapshotKind, Snapshots},
     },
+    pages::theme_packs::ThemePacks,
 };
 
 pub struct Cosmic {
@@ -126,6 +127,7 @@ impl Application for App {
             panel: Panel::default(),
             snapshots: Snapshots::default(),
             shorcuts: Shortcuts::new(),
+            theme_packs: ThemePacks::new(),
         };
 
         let mut tasks = vec![
@@ -211,10 +213,7 @@ impl Application for App {
 
     fn dialog(&self) -> Option<Element<Self::Message>> {
         let spacing = cosmic::theme::spacing();
-        let dialog_page = match self.cosmic.dialog_pages.front() {
-            Some(some) => some,
-            None => return None,
-        };
+        let dialog_page = self.cosmic.dialog_pages.front()?;
 
         let dialog = match dialog_page {
             DialogPage::SaveCurrentColorScheme(name) => widget::dialog()
@@ -282,6 +281,7 @@ impl Application for App {
             Page::Layouts => self.layouts.view().map(Message::Layouts),
             Page::Snapshots => self.snapshots.view().map(Message::Snapshots),
             Page::Shortcuts => self.shorcuts.view().map(Message::Shortcuts),
+            Page::ThemePacks => self.theme_packs.view().map(Message::ThemePacks),
         };
 
         widget::column()
@@ -414,6 +414,9 @@ impl Application for App {
                         .map(cosmic::action::app),
                 ),
             },
+            Message::ThemePacks(message) => {
+                tasks.push(self.theme_packs.update(message).map(cosmic::action::app))
+            }
             Message::SaveNewColorScheme(name) => {
                 tasks.push(self.update(Message::ColorSchemes(Box::new(
                     pages::color_schemes::Message::SaveCurrentColorScheme(Some(name)),

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -11,6 +11,7 @@ pub enum Message {
     Shortcuts(pages::shortcuts::Message),
     Snapshots(pages::snapshots::Message),
     ColorSchemes(Box<pages::color_schemes::Message>),
+    ThemePacks(pages::theme_packs::Message),
     DialogUpdate(DialogPage),
     DialogComplete,
     DialogCancel,

--- a/src/app/page.rs
+++ b/src/app/page.rs
@@ -13,6 +13,7 @@ pub enum Page {
     Layouts,
     Shortcuts,
     Snapshots,
+    ThemePacks,
 }
 
 impl Default for &Page {
@@ -30,6 +31,7 @@ impl Page {
             Self::Layouts => fl!("layouts"),
             Self::Shortcuts => fl!("shortcuts"),
             Self::Snapshots => fl!("snapshots"),
+            Self::ThemePacks => fl!("theme-packs"),
         }
     }
 
@@ -41,6 +43,7 @@ impl Page {
             Self::Layouts => icons::get_icon("view-coverflow-symbolic", 18),
             Self::Shortcuts => icons::get_icon("keyboard-symbolic", 18),
             Self::Snapshots => icons::get_icon("snapshots-symbolic", 18),
+            Self::ThemePacks => icons::get_icon("preferences-color-symbolic", 18),
         }
     }
 
@@ -52,6 +55,7 @@ impl Page {
             Self::Layouts,
             Self::Shortcuts,
             Self::Snapshots,
+            Self::ThemePacks,
         ]
     }
 }

--- a/src/core/grid.rs
+++ b/src/core/grid.rs
@@ -6,12 +6,10 @@ pub struct GridMetrics {
 
 impl GridMetrics {
     pub fn new(width: usize, min_width: usize, column_spacing: u16) -> Self {
-        let width_m1 = width.checked_sub(min_width).unwrap_or(0);
+        let width_m1 = width.saturating_sub(min_width);
         let cols_m1 = width_m1 / (min_width + column_spacing as usize);
         let cols = cols_m1 + 1;
-        let item_width = width
-            .checked_sub(cols_m1 * column_spacing as usize)
-            .unwrap_or(0)
+        let item_width = width.saturating_sub(cols_m1 * column_spacing as usize)
             .checked_div(cols)
             .unwrap_or(0);
         Self {

--- a/src/pages/color_schemes/mod.rs
+++ b/src/pages/color_schemes/mod.rs
@@ -347,7 +347,7 @@ impl ColorSchemes {
         Task::batch(tasks)
     }
 
-    pub fn view<'a>(&'a self) -> Element<'a, Message> {
+    pub fn view(&self) -> Element<'_, Message> {
         let spacing = cosmic::theme::spacing();
         let active_tab = self.model.active_data::<Tab>().unwrap();
         let title = widget::text::title3(fl!("color-schemes"));
@@ -368,7 +368,7 @@ impl ColorSchemes {
             .into()
     }
 
-    fn installed_themes<'a>(&'a self) -> Element<'a, Message> {
+    fn installed_themes(&self) -> Element<'_, Message> {
         if self.installed.is_empty() {
             widget::text("No color schemes installed").into()
         } else {
@@ -408,7 +408,7 @@ impl ColorSchemes {
         }
     }
 
-    fn available_themes<'a>(&'a self) -> Element<'a, Message> {
+    fn available_themes(&self) -> Element<'_, Message> {
         match self.status {
             Status::Idle | Status::LoadingMore => {
                 if self.available.is_empty() {

--- a/src/pages/color_schemes/preview.rs
+++ b/src/pages/color_schemes/preview.rs
@@ -95,8 +95,7 @@ pub fn available<'a>(
                 .push_maybe(
                     color_scheme
                         .author
-                        .as_ref()
-                        .and_then(|author| Some(widget::text::caption(author.clone()))),
+                        .as_ref().map(|author| widget::text::caption(author.clone())),
                 )
                 .width(Length::Fill)
                 .align_x(Alignment::Center)

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -4,6 +4,7 @@ pub mod layouts;
 pub mod panel;
 pub mod shortcuts;
 pub mod snapshots;
+pub mod theme_packs;
 
 pub use color_schemes::ColorSchemes;
 pub use dock::Dock;
@@ -11,3 +12,4 @@ pub use layouts::Layouts;
 pub use panel::Panel;
 pub use shortcuts::Shortcuts;
 pub use snapshots::Snapshots;
+pub use theme_packs::ThemePacks;

--- a/src/pages/theme_packs/mod.rs
+++ b/src/pages/theme_packs/mod.rs
@@ -1,0 +1,516 @@
+pub mod theme_pack;
+
+pub use theme_pack::ThemePack;
+
+use crate::fl;
+use cosmic::{
+    cosmic_config::CosmicConfigEntry,
+    cosmic_theme::ThemeBuilder,
+    dialog::file_chooser::{self, FileFilter},
+    iced, widget, Element, Task,
+};
+use std::{fs, path::PathBuf};
+use url::Url;
+
+// File extension for COSMIC theme packs
+pub const THEME_PACK_EXTENSION: &str = "ctp";
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    ThemeNameChanged(String),
+    ThemeAuthorChanged(String),
+    ThemeDescriptionChanged(String),
+    ExportThemePack,
+    ImportThemePack,
+    ThemePackImported(Option<PathBuf>),
+    SaveThemePack,
+    CancelSaveThemePack,
+    SelectTheme(usize),
+    ApplyThemePack,
+    DeleteThemePack,
+    RefreshThemes,
+    FileDialogCancelled,
+    FileDialogError(String),
+    FileDialogSelected(Url),
+}
+
+#[derive(Debug, Default)]
+pub struct ThemePacks {
+    theme_name: String,
+    theme_description: String,
+    theme_author: String,
+    available_themes: Vec<(String, PathBuf)>,
+    selected_theme: Option<usize>,
+    save_dialog_open: bool,
+}
+
+impl ThemePacks {
+    pub fn new() -> Self {
+        let mut this = Self::default();
+        this.refresh_themes();
+        this
+    }
+
+    pub fn refresh_themes(&mut self) {
+        self.available_themes.clear();
+
+        // Debug log the theme directory
+        let theme_dir = Self::get_theme_dir();
+        log::info!("Looking for theme packs in: {}", theme_dir.display());
+
+        for path in Self::list_available_themes() {
+            if let Some(file_name) = path.file_stem() {
+                if let Some(name) = file_name.to_str() {
+                    log::info!("Found theme pack: {} at {}", name, path.display());
+                    self.available_themes.push((name.to_string(), path));
+                }
+            }
+        }
+
+        log::info!("Total theme packs found: {}", self.available_themes.len());
+    }
+
+    /// Get the default theme pack directory
+    pub fn get_theme_dir() -> PathBuf {
+        let mut path = dirs::config_dir().unwrap_or_default();
+        path.push("cosmic");
+        path.push("theme_packs");
+
+        if !path.exists() {
+            let _ = fs::create_dir_all(&path);
+        }
+
+        path
+    }
+
+    /// List available theme packs in the default directory
+    pub fn list_available_themes() -> Vec<PathBuf> {
+        let dir = Self::get_theme_dir();
+        let mut themes = Vec::new();
+
+        if let Ok(entries) = fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_file()
+                    && path
+                        .extension()
+                        .is_some_and(|ext| ext == THEME_PACK_EXTENSION)
+                {
+                    themes.push(path);
+                }
+            }
+        }
+
+        themes
+    }
+
+    pub fn update(&mut self, message: Message) -> Task<crate::app::message::Message> {
+        match message {
+            Message::ThemeNameChanged(name) => self.theme_name = name,
+            Message::ThemeDescriptionChanged(desc) => self.theme_description = desc,
+            Message::ThemeAuthorChanged(author) => self.theme_author = author,
+            Message::ExportThemePack => self.save_dialog_open = true,
+            Message::SaveThemePack => {
+                self.save_dialog_open = false;
+
+                if self.theme_name.is_empty() {
+                    return Task::none();
+                }
+
+                // Create theme pack from current configuration
+                let theme_pack = match theme_pack::create_theme_pack(
+                    self.theme_name.clone(),
+                    self.theme_author.clone(),
+                    self.theme_description.clone(),
+                ) {
+                    Ok(pack) => pack,
+                    Err(e) => {
+                        log::error!("Failed to create theme pack: {e}");
+                        return Task::none();
+                    }
+                };
+
+                // Save to file
+                let mut path = Self::get_theme_dir();
+                path.push(format!("{}.{}", self.theme_name, THEME_PACK_EXTENSION));
+
+                if let Err(e) = save_theme_pack(&theme_pack, &path) {
+                    log::error!("Failed to save theme pack: {e}");
+                }
+
+                self.refresh_themes();
+            }
+            Message::CancelSaveThemePack => self.save_dialog_open = false,
+            Message::SelectTheme(idx) => self.selected_theme = Some(idx),
+            Message::ApplyThemePack => {
+                if let Some(idx) = self.selected_theme {
+                    if let Some((_, path)) = self.available_themes.get(idx) {
+                        if let Ok(theme_pack) = load_theme_pack(path) {
+                            if let Err(e) = apply_theme_pack(&theme_pack) {
+                                log::error!("Failed to apply theme pack: {e}");
+                            }
+                        }
+                    }
+                }
+            }
+            Message::DeleteThemePack => {
+                if let Some(idx) = self.selected_theme {
+                    if let Some((_, path)) = self.available_themes.get(idx) {
+                        let _ = fs::remove_file(path);
+                        self.refresh_themes();
+                        self.selected_theme = None;
+                    }
+                }
+            }
+            Message::RefreshThemes => self.refresh_themes(),
+            Message::ImportThemePack => {
+                // Use XDG portal file dialog for selecting theme packs
+                return cosmic::task::future(async move {
+                    log::info!("Opening file dialog for theme pack import");
+
+                    // Create a filter for .ctp files
+                    let filter = FileFilter::new("COSMIC Theme Packs")
+                        .glob(&format!("*.{}", THEME_PACK_EXTENSION));
+
+                    let dialog = file_chooser::open::Dialog::new()
+                        .title("Import Theme Pack")
+                        .filter(filter);
+
+                    match dialog.open_file().await {
+                        Ok(response) => crate::app::message::Message::ThemePacks(
+                            Message::FileDialogSelected(response.url().to_owned()),
+                        ),
+                        Err(file_chooser::Error::Cancelled) => {
+                            crate::app::message::Message::ThemePacks(Message::FileDialogCancelled)
+                        }
+                        Err(why) => crate::app::message::Message::ThemePacks(
+                            Message::FileDialogError(format!("File dialog error: {}", why)),
+                        ),
+                    }
+                });
+            }
+            Message::FileDialogCancelled => {
+                log::info!("Theme pack import cancelled");
+            }
+            Message::FileDialogError(error) => {
+                log::error!("Theme pack import error: {}", error);
+            }
+            Message::FileDialogSelected(url) => {
+                log::info!("Selected file from dialog: {}", url);
+
+                // Convert URL to path
+                if let Ok(path) = url.to_file_path() {
+                    return Task::perform(async move { Some(path) }, |result| {
+                        crate::app::message::Message::ThemePacks(Message::ThemePackImported(result))
+                    });
+                } else {
+                    log::error!("Invalid file path from URL: {}", url);
+                }
+            }
+            Message::ThemePackImported(maybe_path) => {
+                if let Some(path) = maybe_path {
+                    // Import theme pack from the selected file
+                    if let Ok(theme_pack) = load_theme_pack(&path) {
+                        // Save it to the theme packs directory
+                        let mut new_path = Self::get_theme_dir();
+                        new_path.push(format!("{}.{}", theme_pack.name, THEME_PACK_EXTENSION));
+
+                        if let Err(e) = save_theme_pack(&theme_pack, &new_path) {
+                            log::error!("Failed to save imported theme pack: {e}");
+                        } else {
+                            log::info!(
+                                "Successfully imported theme pack: {} to {}",
+                                theme_pack.name,
+                                new_path.display()
+                            );
+                        }
+                    } else {
+                        log::error!("Failed to load theme pack from: {}", path.display());
+                    }
+
+                    // Refresh the list
+                    self.refresh_themes();
+                }
+            }
+        }
+
+        Task::none()
+    }
+
+    pub fn view(&self) -> Element<Message> {
+        let spacing = cosmic::theme::spacing();
+
+        // Create theme form
+        let create_theme_form = widget::column()
+            .push(widget::text::title4(fl!("create-new-theme")))
+            .push(
+                widget::column()
+                    .push(widget::text::body(fl!("name")))
+                    .push(
+                        widget::text_input("", &self.theme_name)
+                            .on_input(Message::ThemeNameChanged)
+                            .padding(spacing.space_xxs),
+                    )
+                    .spacing(spacing.space_xxs),
+            )
+            .push(
+                widget::column()
+                    .push(widget::text::body(fl!("author")))
+                    .push(
+                        widget::text_input("", &self.theme_author)
+                            .on_input(Message::ThemeAuthorChanged)
+                            .padding(spacing.space_xxs),
+                    )
+                    .spacing(spacing.space_xxs),
+            )
+            .push(
+                widget::column()
+                    .push(widget::text::body(fl!("description")))
+                    .push(
+                        widget::text_input("", &self.theme_description)
+                            .on_input(Message::ThemeDescriptionChanged)
+                            .padding(spacing.space_xxs),
+                    )
+                    .spacing(spacing.space_xxs),
+            )
+            .push(
+                widget::row()
+                    .push(widget::horizontal_space())
+                    .push(
+                        widget::button::standard(fl!("export-theme"))
+                            .on_press(Message::ExportThemePack),
+                    )
+                    .spacing(spacing.space_xxs),
+            )
+            .spacing(spacing.space_m)
+            .padding(spacing.space_m);
+
+        // Create form container
+        let create_form_container = widget::container(create_theme_form)
+            .padding(spacing.space_m)
+            .style(|_| widget::container::Style::default());
+
+        // Available themes section with import button
+        let available_themes_header = widget::row()
+            .push(widget::text::title4(fl!("available-themes")))
+            .push(widget::horizontal_space())
+            .push(
+                widget::button::standard(fl!("import-color-scheme")) // Reuse existing translation
+                    .on_press(Message::ImportThemePack),
+            )
+            .width(iced::Length::Fill);
+
+        let available_themes_section = if self.available_themes.is_empty() {
+            widget::column()
+                .push(available_themes_header)
+                .push(widget::text::body(fl!("no-themes-available")))
+                .spacing(spacing.space_m)
+                .padding(spacing.space_m)
+                .width(iced::Length::Fill)
+        } else {
+            let mut column = widget::column()
+                .push(available_themes_header)
+                .spacing(spacing.space_m)
+                .padding(spacing.space_m)
+                .width(iced::Length::Fill);
+
+            // Create a list of available themes
+            for (idx, (name, _)) in self.available_themes.iter().enumerate() {
+                let theme_row = widget::row()
+                    .push(widget::text::body(name.clone()).width(iced::Length::Fill))
+                    .push(widget::radio(
+                        "",
+                        idx,
+                        self.selected_theme,
+                        Message::SelectTheme,
+                    ))
+                    .spacing(spacing.space_m);
+
+                column = column.push(theme_row);
+            }
+
+            // Add action buttons for selected theme
+            if self.selected_theme.is_some() {
+                column = column.push(
+                    widget::row()
+                        .push(widget::horizontal_space())
+                        .push(
+                            widget::button::standard(fl!("apply"))
+                                .on_press(Message::ApplyThemePack),
+                        )
+                        .push(
+                            widget::button::destructive(fl!("delete"))
+                                .on_press(Message::DeleteThemePack),
+                        )
+                        .spacing(spacing.space_xxs),
+                );
+            }
+
+            column
+        };
+
+        let available_themes_container = widget::container(available_themes_section)
+            .padding(spacing.space_m)
+            .style(|_| widget::container::Style::default());
+
+        // If save dialog is open, show the confirmation dialog
+        if self.save_dialog_open {
+            widget::container(
+                widget::column()
+                    .push(widget::text::title4(fl!("save-theme-confirmation")))
+                    .push(
+                        widget::row()
+                            .push(widget::horizontal_space())
+                            .push(
+                                widget::button::standard(fl!("cancel"))
+                                    .on_press(Message::CancelSaveThemePack),
+                            )
+                            .push(
+                                widget::button::suggested(fl!("save"))
+                                    .on_press(Message::SaveThemePack),
+                            )
+                            .spacing(spacing.space_xxs),
+                    )
+                    .spacing(spacing.space_m)
+                    .padding(spacing.space_m),
+            )
+            .width(iced::Length::Fill)
+            .height(iced::Length::Fill)
+            .style(|_| widget::container::Style::default())
+            .into()
+        } else {
+            // Main layout with content section
+            let content = widget::column()
+                .push(create_form_container)
+                .push(available_themes_container)
+                .spacing(spacing.space_m);
+
+            widget::settings::view_column(vec![widget::settings::section()
+                .title(fl!("theme-packs"))
+                .add(content)
+                .into()])
+            .into()
+        }
+    }
+}
+
+fn save_theme_pack(
+    theme_pack: &ThemePack,
+    path: &PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let json = ron::to_string(theme_pack)?;
+    std::fs::write(path, json)?;
+
+    log::info!("Theme pack saved to: {}", path.display());
+
+    Ok(())
+}
+
+fn load_theme_pack(path: &PathBuf) -> Result<ThemePack, Box<dyn std::error::Error>> {
+    let content = fs::read_to_string(path)?;
+    let theme_pack: ThemePack = ron::from_str(&content)?;
+    Ok(theme_pack)
+}
+
+fn apply_theme_pack(theme_pack: &ThemePack) -> Result<(), Box<dyn std::error::Error>> {
+    // Apply the color scheme by saving it to the appropriate location
+    log::info!("Applying color scheme from theme pack: {}", theme_pack.name);
+
+    // Try to parse the theme from the color scheme
+    let color_scheme = &theme_pack.color_scheme.theme_builder_ron;
+
+    // Try to parse the theme_builder_ron as a ThemeBuilder
+    let theme_builder: ThemeBuilder = match ron::from_str(color_scheme) {
+        Ok(builder) => builder,
+        Err(e) => {
+            // Parsing directly fails, try to parse as a ColorScheme
+            match ron::from_str::<crate::pages::color_schemes::config::ColorScheme>(color_scheme) {
+                Ok(color_scheme) => color_scheme.theme,
+                Err(_) => {
+                    return Err(Box::new(e));
+                }
+            }
+        }
+    };
+
+    // Save color scheme for reference
+    let mut theme_pack_path = dirs::data_local_dir().unwrap_or_default();
+    theme_pack_path.push("theme_packs/cosmic");
+
+    if !theme_pack_path.exists() {
+        fs::create_dir_all(&theme_pack_path)?;
+    }
+
+    theme_pack_path.push(format!("{}.ron", theme_pack.name));
+
+    // Save the theme pack to the theme pack directory (for reference only)
+    fs::write(&theme_pack_path, &theme_pack.color_scheme.theme_builder_ron)?;
+
+    // Get current theme mode to determine which config to update
+    let theme_mode_config = cosmic::cosmic_theme::ThemeMode::config().map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Failed to get theme mode config: {e}"),
+        )
+    })?;
+
+    let theme_mode =
+        cosmic::cosmic_theme::ThemeMode::get_entry(&theme_mode_config).map_err(|(e, _)| {
+            let error_str = e
+                .into_iter()
+                .map(|err| err.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            std::io::Error::new(std::io::ErrorKind::Other, error_str)
+        })?;
+
+    // Update the corresponding config based on the theme mode
+    let config = if theme_mode.is_dark {
+        // Get dark theme config
+        cosmic::cosmic_theme::Theme::dark_config().map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to get dark theme config: {e}"),
+            )
+        })?
+    } else {
+        // Get light theme config
+        cosmic::cosmic_theme::Theme::light_config().map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to get light theme config: {e}"),
+            )
+        })?
+    };
+
+    // Write the theme
+    if let Err(e) = theme_builder.build().write_entry(&config) {
+        log::error!("Failed to write the theme config: {e}");
+        return Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Failed to write them config: {e}"),
+        )));
+    }
+
+    log::info!("Applied color scheme from theme pack: {}", theme_pack.name);
+
+    // Apply the panel config
+    log::info!(
+        "Applying panel config from theme pack: {}",
+        &theme_pack.name
+    );
+
+    // Apply the Panel Schema as the theme pack layout
+    if let Err(e) = cosmic_ext_config_templates::load_template(theme_pack.layout.clone()) {
+        log::error!("Failed to apply layout schema: {e}");
+        return Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Failed to load theme pack layout template: {e}"),
+        )));
+    }
+
+    log::info!("Successfully applied layout from theme pack");
+
+    Ok(())
+}

--- a/src/pages/theme_packs/theme_pack.rs
+++ b/src/pages/theme_packs/theme_pack.rs
@@ -1,0 +1,57 @@
+use cosmic_ext_config_templates::Schema;
+use serde::{Deserialize, Serialize};
+
+use crate::core::resources;
+use crate::pages::color_schemes::config::ColorScheme;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ColorSchemeConfig {
+    pub theme_builder_ron: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PanelConfig {
+    pub panel_ron: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ThemePack {
+    // Metadata
+    pub name: String,
+    pub author: String,
+    pub description: String,
+    pub version: String,
+
+    // Configurations
+    pub color_scheme: ColorSchemeConfig,
+    pub layout: Schema,
+}
+
+pub fn create_theme_pack(
+    name: impl Into<String>,
+    author: impl Into<String>,
+    description: impl Into<String>,
+) -> Result<ThemePack, ron::error::Error> {
+    // Get the current color scheme
+    let color_scheme = ColorScheme::current_theme();
+    let color_scheme_ron = ron::to_string(&color_scheme)?;
+
+    // Generate a Schema for the current panel/dock configuration
+    let layout = cosmic_ext_config_templates::panel::PanelSchema::generate()
+        .map(Schema::Panel)
+        .unwrap_or_else(|_| {
+            // Fallback to COSMIC layout if we can't generate one
+            ron::from_str::<Schema>(resources::COSMIC_LAYOUT).unwrap()
+        });
+
+    Ok(ThemePack {
+        name: name.into(),
+        author: author.into(),
+        description: description.into(),
+        version: "1.0.0".into(),
+        color_scheme: ColorSchemeConfig {
+            theme_builder_ron: color_scheme_ron,
+        },
+        layout,
+    })
+}


### PR DESCRIPTION
# Theme Packs
The idea of a theme pack is that it bundles the color scheme and layout together in one package to be applied together into one coherent theme.

## Implementation
### Theme Pack Page
Consists of a form for creating a new theme pack at the top of the page. Underneath the `Create New Theme` section is the `Available Themes` section where the user can import a theme pack or apply a theme pack that has been either created or imported.

Created and imported theme packs can also be deleted/removed from the page.

![Screenshot_2025-05-17_23-33-28](https://github.com/user-attachments/assets/a20a6633-8d64-4b37-8670-62c76eb80a5f)

![Screenshot_2025-05-17_23-33-38](https://github.com/user-attachments/assets/118870b5-edf7-4fe9-8226-22bd30ed4f28)

### Export Theme
After the user gives the theme a name, author, and description they click the export theme button. From here it exports the theme into the theme_packs directory of the application and becomes available in the `Available Themes` section.

### Import Theme Pack
This button opens a native file dialog and allows the user to navigate to and select the theme pack file. COSMIC theme pack files are basically .ron with a `.ctp` extension to clearly define they are COSMIC theme pack files.