### PR TITLE
Add color scheme to snapshot data

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6,14 +6,15 @@ use cosmic::{
 };
 use std::collections::{HashMap, VecDeque};
 
+use crate::app::pages::color_schemes::config::ColorScheme;
 use dialog::DialogPage;
 use flags::Flags;
 use message::Message;
-use crate::app::pages::color_schemes::config::ColorScheme;
 
 pub mod action;
 pub mod context;
 pub mod context_drawer;
+pub mod core;
 pub mod dialog;
 pub mod flags;
 pub mod footer;
@@ -22,11 +23,10 @@ pub mod init;
 pub mod message;
 pub mod nav;
 pub mod page;
+pub mod pages;
 pub mod subscription;
 pub mod update;
 pub mod view;
-pub mod pages;
-pub mod core;
 
 pub struct App {
     cosmic: Cosmic,

--- a/src/app/footer.rs
+++ b/src/app/footer.rs
@@ -19,9 +19,9 @@ impl Cosmic {
     pub fn footer(app: &App) -> Option<Element<Message>> {
         let spacing = cosmic::theme::spacing();
 
-        match app.cosmic.nav_model.active_data::<Page>() {
-            Some(Page::ColorSchemes) => match app.color_schemes.model.active_data::<Tab>() {
-                Some(Tab::Installed) => Some(
+        match app.cosmic.nav_model.active_data::<Page>()? {
+            Page::ColorSchemes => match app.color_schemes.model.active_data::<Tab>()? {
+                Tab::Installed => Some(
                     widget::row()
                         .push(widget::horizontal_space())
                         .push(
@@ -46,7 +46,7 @@ impl Cosmic {
                         .padding(spacing.space_xxs)
                         .into(),
                 ),
-                Some(Tab::Available) => Some(
+                Tab::Available => Some(
                     widget::row()
                         .push(widget::horizontal_space())
                         .push(match app.color_schemes.status {
@@ -71,9 +71,8 @@ impl Cosmic {
                         .padding(spacing.space_xxs)
                         .into(),
                 ),
-                None => None,
             },
-            Some(Page::Layouts) => Some(
+            Page::Layouts => Some(
                 widget::row()
                     .push(widget::horizontal_space())
                     .push(
@@ -112,7 +111,7 @@ impl Cosmic {
                     .padding(spacing.space_xxs)
                     .into(),
             ),
-            Some(Page::Snapshots) => Some(
+            Page::Snapshots => Some(
                 widget::row()
                     .push(widget::horizontal_space())
                     .push(

--- a/src/app/pages/color_schemes/mod.rs
+++ b/src/app/pages/color_schemes/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use self::config::ColorScheme;
+use crate::app::core::grid::GridMetrics;
 use crate::fl;
 use ashpd::desktop::file_chooser::{FileFilter, SelectedFiles};
 use cosmic::{
@@ -14,7 +15,6 @@ use cosmic::{
     Element, Task,
 };
 use cosmic_theme::CosmicTheme;
-use crate::app::core::grid::GridMetrics;
 
 pub mod config;
 pub mod cosmic_theme;
@@ -213,12 +213,9 @@ impl ColorSchemes {
                     log::error!("There was an error selecting the color scheme: {e}");
                 }
 
-                if color_scheme.theme != ThemeBuilder::default() {
-                    log::info!("Theme is not default, setting the theme...");
-                    if let Ok(theme) = &color_scheme.read_theme() {
-                        log::info!("Color scheme has a theme, setting the theme...");
-                        tasks.push(self.update(Message::ImportSuccess(Box::new(theme.clone()))))
-                    }
+                if let Ok(theme) = &color_scheme.read_theme() {
+                    log::info!("Color scheme has a theme, setting the theme...");
+                    tasks.push(self.update(Message::ImportSuccess(Box::new(theme.clone()))))
                 }
             }
             Message::DeleteColorScheme(color_scheme) => {

--- a/src/app/pages/color_schemes/preview.rs
+++ b/src/app/pages/color_schemes/preview.rs
@@ -1,14 +1,14 @@
+use super::config::ColorScheme;
+use crate::app::core::{
+    icons,
+    style::{destructive_button, link_button, standard_button},
+};
 use crate::fl;
 use cosmic::{
     iced::{Alignment, Length},
     widget::{self, tooltip},
     Apply, Element,
 };
-use crate::app::core::{
-    icons,
-    style::{destructive_button, link_button, standard_button},
-};
-use super::config::ColorScheme;
 
 pub fn installed<'a>(
     color_scheme: &ColorScheme,
@@ -41,6 +41,7 @@ pub fn installed<'a>(
                         .apply(widget::button::icon)
                         .class(link_button(theme.clone()))
                         .padding(spacing.space_xxs)
+                        .selected(color_scheme.name == selected.name)
                         .class(if selected.name == color_scheme.name {
                             cosmic::style::Button::Standard
                         } else {


### PR DESCRIPTION
This pull request introduces `ColorScheme` data to snapshots.

* Introduced `color_scheme` as a property of `Snapshot` and added logic to load the color scheme configuration during snapshot creation. Improved error handling for schema loading. 
* Enhanced error handling for directory access and snapshot restoration. Added logic to restore the associated `ColorScheme` during snapshot restoration.

This should conclude #79 