### PR TITLE
Add animation speed controls for panels

### DIFF
--- a/i18n/en/cosmic_ext_tweaks.ftl
+++ b/i18n/en/cosmic_ext_tweaks.ftl
@@ -9,6 +9,7 @@ color-schemes = Color schemes
 layouts = Layouts
 shortcuts = Shortcuts
 snapshots = Snapshots
+animation = Animation
 
 create-layout = Create layout
 apply-layout = Apply layout
@@ -48,17 +49,23 @@ available = Available
 loading = Loading...
 show-more = Show more
 
+## Panel
 show-panel = Show panel
 show-dock = Show dock
 force-icon-buttons-in-panel = Force icon buttons in panel
 size = Size
 size-description = The height of the panel and applets
-
 padding = Padding
 padding-description = Padding is the space between the contents and the borders of the dock or panel.
-
 spacing = Spacing
 spacing-description = Spacing is the space between the icons in the dock or panel.
+animation-speed = Animation speed
+wait-time = Wait time
+wait-time-description = Wait time is the time it takes for the panel to hide after the mouse leaves it.
+transition-time = Transition time
+transition-time-description = Transition time is the time it takes for the panel to show or hide.
+handle-size = Handle size
+handle-size-description = Handle size is the size of the handle that allows you to resize the panel.
 
 save = Save
 cancel = Cancel


### PR DESCRIPTION
This PR adds support to change show/hide animation speed for panel.

<img width="1270" height="705" alt="image" src="https://github.com/user-attachments/assets/e0e1dfd9-9fa7-4fa6-b757-a110b92cefb5" />

Closes #92 