### PR TITLE
fix: unwrap in autohide

### DIFF
--- a/src/app/pages/panel/mod.rs
+++ b/src/app/pages/panel/mod.rs
@@ -123,8 +123,8 @@ impl Default for Panel {
             .unwrap_or(false);
         let autohide = panel_config
             .clone()
-            .map(|config| config.autohide.unwrap_or(AutoHide::default()))
-            .unwrap();
+            .map(|config| config.autohide.unwrap_or_default())
+            .unwrap_or(AutoHide::default());
 
         Self {
             panel_helper,


### PR DESCRIPTION
This pull request fixes an `unwrap` call to the `autohide` setting in panel.