### PR TITLE
fix(snapshots): Display created time in local timezone

### DIFF
--- a/src/app/pages/snapshots/config.rs
+++ b/src/app/pages/snapshots/config.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, path::PathBuf};
 
 use crate::app::App;
-use chrono::{NaiveDateTime, Utc};
+use chrono::{DateTime, Local, Utc};
 use cosmic::Application;
 use cosmic_ext_config_templates::{Schema, panel::PanelSchema};
 use serde::{Deserialize, Serialize};
@@ -12,7 +12,7 @@ pub struct Snapshot {
     pub id: Uuid,
     pub name: String,
     pub kind: SnapshotKind,
-    pub created: NaiveDateTime,
+    pub created: DateTime<Utc>,
     pub schema: Option<Schema>,
 }
 
@@ -35,7 +35,7 @@ impl Display for SnapshotKind {
 impl Snapshot {
     pub fn new(name: impl ToString, kind: SnapshotKind) -> Self {
         let id = Uuid::new_v4();
-        let created = Utc::now().naive_local();
+        let created = Utc::now();
 
         Self {
             id,
@@ -47,7 +47,10 @@ impl Snapshot {
     }
 
     pub fn created(&self) -> String {
-        self.created.format("%Y-%m-%d %H:%M:%S").to_string()
+        self.created
+            .with_timezone(&Local)
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string()
     }
 
     pub fn path(&self) -> PathBuf {

--- a/src/app/pages/snapshots/mod.rs
+++ b/src/app/pages/snapshots/mod.rs
@@ -132,12 +132,7 @@ impl Snapshots {
         match message {
             Message::ReloadSnapshots => {
                 self.snapshots = Snapshots::list();
-                self.snapshots.sort_by(|a, b| {
-                    b.created
-                        .and_utc()
-                        .timestamp()
-                        .cmp(&a.created.and_utc().timestamp())
-                });
+                self.snapshots.sort_by(|a, b| b.created.cmp(&a.created));
             }
             Message::RestoreSnapshot(snapshot) => {
                 if let Some(schema) = snapshot.schema {


### PR DESCRIPTION
Store snapshot creation time as DateTime<Utc> and convert to local timezone when displaying, instead of using NaiveDateTime which loses timezone information.